### PR TITLE
Whole-image format conversion

### DIFF
--- a/src/wg/color/rgb/convert.d
+++ b/src/wg/color/rgb/convert.d
@@ -1,0 +1,173 @@
+// Written in the D programming language.
+/**
+RGB colour conversion.
+
+Authors:    Manu Evans
+Copyright:  Copyright (c) 2019, Manu Evans.
+License:    $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0)
+*/
+
+module wg.color.rgb.convert;
+
+import wg.color.rgb;
+
+/**
+* Unpack RGB color to float.
+* 
+* Params:
+* $(D_INLINECODE element) = An RGB image element.
+* $(D_INLINECODE format) = An RGB format descriptor for the element.
+*/
+float[4] unpackRgbColor(bool outputLinear = false)(const(void)[] element, ref const(RGBFormatDescriptor) format)
+    in(element.length == format.bits / 8)
+{
+    import wg.util.packedfloat;
+    import wg.util.util : _max;
+
+    float[4] r = void;
+
+    // determine component indices
+    int[4] cmpIndex = void;
+    cmpIndex[0] = format.componentIndex[RGBFormatDescriptor.Component.Luma];
+    if (cmpIndex[0] >= 0)
+        cmpIndex[1] = cmpIndex[2] = cmpIndex[0];
+    else
+    {
+        cmpIndex[0] = format.componentIndex[RGBFormatDescriptor.Component.Red];
+        cmpIndex[1] = format.componentIndex[RGBFormatDescriptor.Component.Green];
+        cmpIndex[2] = format.componentIndex[RGBFormatDescriptor.Component.Blue];
+    }
+    cmpIndex[3] = format.componentIndex[RGBFormatDescriptor.Component.Alpha];
+
+    // check for fast-path
+    if ((format.flags & (RGBFormatDescriptor.Flags.AllAligned | RGBFormatDescriptor.Flags.AllSameSize)) == (RGBFormatDescriptor.Flags.AllAligned | RGBFormatDescriptor.Flags.AllSameSize))
+    {
+        static float[4] unpack(U, S, F)(const(void)* element, ref int[4] index, ref const(RGBFormatDescriptor) format)
+        {
+            enum bits = U.sizeof * 8;
+            float[4] r = void;
+            switch (format.componentData[0].format)
+            {
+                case RGBFormatDescriptor.Format.NormInt:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? (cast(U*)element)[format.componentData[index[i]].offset / bits] * (1.0f/U.max) : 0.0f;
+                    break;
+                case RGBFormatDescriptor.Format.SignedNormInt:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? _max((cast(S*)element)[format.componentData[index[i]].offset / bits] * (1.0f/S.max), -1.0f) : 0.0f;
+                    break;
+                case RGBFormatDescriptor.Format.FloatingPoint:
+                    static if (!is(F == void))
+                    {
+                        static foreach (i; 0 .. 4)
+                            r[i] = index[i] >= 0 ? cast(float)(cast(F*)element)[format.componentData[index[i]].offset / bits] : 0.0f;
+                        break;
+                    }
+                    else
+                        assert(false, "TODO: what should this do?");
+                case RGBFormatDescriptor.Format.FixedPoint:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? (cast(U*)element)[format.componentData[index[i]].offset / bits] * (1.0f/(1 << format.componentData[index[i]].fracBits)) : 0.0f;
+                    break;
+                case RGBFormatDescriptor.Format.SignedFixedPoint:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? (cast(S*)element)[format.componentData[index[i]].offset / bits] * (1.0f/(1 << format.componentData[index[i]].fracBits)) : 0.0f;
+                    break;
+                case RGBFormatDescriptor.Format.UnsignedInt:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? cast(float)(cast(U*)element)[format.componentData[index[i]].offset / bits] : 0.0f;
+                    break;
+                case RGBFormatDescriptor.Format.SignedInt:
+                    static foreach (i; 0 .. 4)
+                        r[i] = index[i] >= 0 ? cast(float)(cast(S*)element)[format.componentData[index[i]].offset / bits] : 0.0f;
+                    break;
+                default:
+                    assert(false, "how did this happen?");
+            }
+            return r;
+        }
+
+        // simple case
+        switch (format.componentData[0].bits / 8)
+        {
+            case 1:
+                r = unpack!(ubyte, byte, void)(element.ptr, cmpIndex, format);
+                break;
+            case 2:
+                r = unpack!(ushort, short, PackedFloat!(ushort, 16, true, 5))(element.ptr, cmpIndex, format);
+                break;
+            case 4:
+                r = unpack!(uint, int, float)(element.ptr, cmpIndex, format);
+                break;
+            case 8:
+                r = unpack!(ulong, long, double)(element.ptr, cmpIndex, format);
+                break;
+            default:
+                assert(false, "TODO: how did we get here?");
+        }
+    }
+    else
+    {
+        static float unpack(ulong bits, ref const(RGBFormatDescriptor.ComponentDesc) component) pure nothrow @nogc
+        {
+            ulong mask = (1 << component.bits) - 1;
+            switch(component.format)
+            {
+                case RGBFormatDescriptor.Format.NormInt:
+                    bits = (bits >> component.offset) & mask;
+                    return bits / float(mask);
+
+                case RGBFormatDescriptor.Format.SignedNormInt:
+                    long sbits = bits << (64 - component.offset - component.bits);
+                    sbits = (sbits >> (64 - component.bits)) & mask;
+                    return _max(sbits / float(mask >> 1), -1.0f);
+
+                case RGBFormatDescriptor.Format.FloatingPoint:
+                    assert(false, "TODO: gotta do packed small-floats...");
+
+                case RGBFormatDescriptor.Format.FixedPoint:
+                    bits = (bits >> component.offset) & mask;
+                    return bits / float(1 << component.fracBits);
+
+                case RGBFormatDescriptor.Format.SignedFixedPoint:
+                    long sbits = bits << (64 - component.offset - component.bits);
+                    sbits = (sbits >> (64 - component.bits)) & mask;
+                    return sbits / float(1 << component.fracBits);
+
+                case RGBFormatDescriptor.Format.UnsignedInt:
+                    bits = (bits >> component.offset) & mask;
+                    return cast(float)bits;
+
+                case RGBFormatDescriptor.Format.SignedInt:
+                    long sbits = bits << (64 - component.offset - component.bits);
+                    sbits = (sbits >> (64 - component.bits)) & mask;
+                    return cast(float)sbits;
+                default:
+                    assert(false);
+            }
+        }
+
+        // bit packed
+        byte expIndex = format.componentIndex[RGBFormatDescriptor.Component.Exponent];
+        assert(expIndex < 0, "TODO: shared exponent...");
+
+        ulong bits;
+        switch (element.length)
+        {
+            case 1: bits = *cast(ubyte*)element.ptr; break;
+            case 2: bits = *cast(ushort*)element.ptr; break;
+            case 4: bits = *cast(uint*)element.ptr; break;
+            case 8: bits = *cast(ulong*)element.ptr; break;
+            default: (cast(void*)&bits)[0 .. element.length] = element[]; break;
+        }
+        static foreach (i; 0 .. 4)
+            r[i] = cmpIndex[i] >= 0 ? unpack(bits, format.componentData[cmpIndex[i]]) : 0.0f;
+    }
+
+    static if (outputLinear)
+    {
+        static assert(false, "TODO: do gamma conversion...");
+    }
+
+    return r;
+}

--- a/src/wg/image/transform.d
+++ b/src/wg/image/transform.d
@@ -1,6 +1,6 @@
 // Written in the D programming language.
 /**
-Some sample image transformations.
+Image transformations.
 
 Authors:    Manu Evans
 Copyright:  Copyright (c) 2019, Manu Evans.
@@ -35,10 +35,12 @@ Image crop(Image)(ref Image image, uint left, uint right, uint top, uint bottom)
     return r;
 }
 
-/// TODO: deallocate? must retain allocation metadata, otherwise can't free!
+/// strip all metadata from an image buffer
 Image stripMetadata(Image)(ref Image image) if (isImageBuffer!Image)
 {
     Image r = image;
+
+    // TODO: must find and keep the allocation metadata!
     r.metadata = null;
     return r;
 }
@@ -46,3 +48,141 @@ Image stripMetadata(Image)(ref Image image) if (isImageBuffer!Image)
 // TODO: flip (in-place support?)
 // TODO: flip (not in-place, buffer)
 // TODO: rotation (requires destination image buffer, with matching format)
+
+/// Map image elements 
+auto map(Img, Fn)(auto ref Img image, auto ref Fn mapFunc)
+{
+    static struct Map
+    {
+        alias width = image.width;
+        alias height = image.height;
+
+        auto at(uint x, uint y) const
+        {
+            return mapFunc(image.at(x, y));
+        }
+
+    private:
+        Img image;
+        Fn mapFunc;
+    }
+
+    return Map(image);
+}
+
+/// Convert image format
+auto convert(TargetFormat, Img)(auto ref Img image) if (isImage!Img && isValidPixelType!TargetFormat)
+{
+    import wg.color : convertColor;
+
+    return image.map((ElementType!Img1 e) => e.convertColor!TargetFormat());
+}
+
+/// Convert image format
+auto convert(TargetFormat)(auto ref ImageBuffer image) if (isValidPixelType!TargetFormat)
+{
+    import wg.color : convertColor;
+    import wg.color.rgb : RGB;
+    import wg.color.rgb.colorspace : RGBColorSpace, parseRGBColorSpace;
+    import wg.color.rgb.convert : unpackRgbColor;
+    import wg.color.rgb.format : RGBFormatDescriptor, parseRGBFormat, makeFormatString;
+    import wg.image.format;
+
+    // TODO: check if image is already the target format (and use a pass-through path)
+
+    static struct DynamicConv
+    {
+        alias ConvertFunc = TargetFormat function(const(void)*, ref const(RGBFormatDescriptor) rgbDesc);
+
+        this()(auto ref ImageBuffer image)
+        {
+            this.image = image;
+
+            assert((image.bitsPerBlock & 7) == 0);
+            elementBytes = image.bitsPerBlock / 8;
+
+            const(char)[] format = image.format;
+            switch(getFormatFamily(format))
+            {
+                case "rgb":
+                    rgbFormat = parseRGBFormat(format);
+
+                    static if (is(TargetFormat == RGB!targetFmt, string targetFmt))
+                    {
+                        if (rgbFormat.colorSpace[] == TargetFormat.Format.colorSpace[])
+                        {
+                            // make the unpack format string
+                            static if (TargetFormat.Format.colorSpace[] != "sRGB")
+                            {
+                                // we need to inject the target colourspace into our desired format
+                                enum unpackDesc = (RGBFormatDescriptor desc) {
+                                    desc.colorSpace = TargetFormat.Format.colorSpace;
+                                    return desc;
+                                }(parseRGBFormat("rgba_f32_f32_f32_f32"));
+                                enum string unpackFormat = makeFormatString(unpackDesc);
+                            }
+                            else
+                                enum string unpackFormat = "rgba_f32_f32_f32_f32";
+
+                            alias UnpackType = RGB!unpackFormat;
+
+                            convFun = (const(void)* e, ref const(RGBFormatDescriptor) desc) {
+                                float[4] unpack = unpackRgbColor(e[0 .. desc.bits/8], desc);
+                                return UnpackType(unpack[0], unpack[1], unpack[2], unpack[3]).convertColor!TargetFormat();
+                            };
+                            break;
+                        }
+                        else
+                        {
+                            RGBColorSpace cs = parseRGBColorSpace(rgbFormat.colorSpace);
+
+                            if (cs.red   == TargetFormat.ColorSpace.red   &&
+                                cs.green == TargetFormat.ColorSpace.green &&
+                                cs.blue  == TargetFormat.ColorSpace.blue  &&
+                                cs.white == TargetFormat.ColorSpace.white)
+                            {
+                                // same colourspace, only gamma transformation
+                                //convFun = ...
+                                assert(false);
+                            }
+                        }
+                    }
+
+                    // unpack to linear
+                    // convert to XYZ
+
+                    assert(false);
+                    //                    break;
+                case "xyz":
+                    import wg.color.xyz;
+                    if (format == XYZ.stringof)
+                        convFun = (const(void)* e, ref const(RGBFormatDescriptor)) => (*cast(const(XYZ)*)e).convertColor!TargetFormat();
+                    else if (format == xyY.stringof)
+                        convFun = (const(void)* e, ref const(RGBFormatDescriptor)) => (*cast(const(xyY)*)e).convertColor!TargetFormat();
+                    else
+                        assert(false, "Unknown XYZ format!");
+                    break;
+                default:
+                    assert(false, "TODO: source format not supported: " ~ format);
+            }
+        }
+
+        @property uint width() const { return image.width; }
+        @property uint height() const { return image.height; }
+
+        auto at(uint x, uint y) const
+        {
+            assert(x < width && y < height);
+
+            size_t offset = y*image.rowPitch + x*elementBytes;
+            return convFun(image.data + offset, rgbFormat);
+        }
+
+        ImageBuffer image;
+        size_t elementBytes;
+        ConvertFunc convFun;
+        RGBFormatDescriptor rgbFormat;
+    }
+
+    return DynamicConv(image);
+}


### PR DESCRIPTION
Perform format-conversion on strongly-typed images (fairly fast), and dynamically typed images (slow, but loads of optimisations are possible).

Includes the dynamic RGB conversion code, which is kind of extensive.